### PR TITLE
Allowing underscore in HTTP header names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Setup PHP
-              uses: shivammathur/setup-php@2.19.1
+              uses: shivammathur/setup-php@2.22.0
               with:
                   php-version: ${{ matrix.php-versions }}
                   extensions: mbstring

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
-        "phpstan/phpstan": "1.5.7",
-        "friendsofphp/php-cs-fixer": "3.8.0",
+        "phpstan/phpstan": "1.9.2",
+        "friendsofphp/php-cs-fixer": "3.13.0",
         "maglnet/composer-require-checker": "^3.0.0",
         "phpro/grumphp-shim": "^1.5.0"
     },
@@ -52,5 +52,10 @@
         "ext-curl": "Required by the Zend_Http_Client_Adapter_Curl adapter",
         "ext-zlib": "Required to compress/decompress gzipped request/response",
         "ext-fileinfo": "If installed, will be used for mime type detection"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpro/grumphp-shim": true
+        }
     }
 }

--- a/src/Zend/Http/Client.php
+++ b/src/Zend/Http/Client.php
@@ -415,7 +415,7 @@ class Zend_Http_Client
         }
 
         // Make sure the name is valid if we are in strict mode
-        if ($this->config['strict'] && (! preg_match('/^[a-zA-Z0-9-]+$/', $name))) {
+        if ($this->config['strict'] && (! preg_match('/^[a-zA-Z0-9-_]+$/', $name))) {
             throw new Zend_Http_Client_Exception("{$name} is not a valid HTTP header name");
         }
 

--- a/src/Zend/Http/Client.php
+++ b/src/Zend/Http/Client.php
@@ -239,7 +239,7 @@ class Zend_Http_Client
      * This variable is populated the first time _detectFileMimeType is called
      * and is then reused on every call to this method
      *
-     * @var resource
+     * @var resource|false
      */
     protected static $_fileInfoDb = null;
 

--- a/src/Zend/Http/Client.php
+++ b/src/Zend/Http/Client.php
@@ -579,7 +579,7 @@ class Zend_Http_Client
                 $this->getUri()->setUsername('');
                 $this->getUri()->setPassword('');
             }
-            // Else, set up authentication
+        // Else, set up authentication
         } else {
             // Check we got a proper authentication type
             if (! defined('self::AUTH_' . strtoupper($type))) {
@@ -1083,7 +1083,6 @@ class Zend_Http_Client
 
             // If we got redirected, look for the Location header
             if ($response->isRedirect() && ($location = $response->getHeader('location'))) {
-
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers (See ZF-11283)
                 $location = trim($location);
@@ -1102,7 +1101,6 @@ class Zend_Http_Client
                     $this->setHeaders('host', null);
                     $this->setUri($location);
                 } else {
-
                     // Split into path and query and set the query
                     if (strpos($location, '?') !== false) {
                         list($location, $query) = explode('?', $location, 2);
@@ -1474,7 +1472,7 @@ class Zend_Http_Client
                 $authHeader = 'Basic ' . base64_encode($user . ':' . $password);
                 break;
 
-            //case self::AUTH_DIGEST:
+                //case self::AUTH_DIGEST:
                 /**
                  * @todo Implement digest authentication
                  */
@@ -1510,7 +1508,6 @@ class Zend_Http_Client
         $parameters = array();
 
         foreach ($parray as $name => $value) {
-
             // Calculate array key
             if ($prefix) {
                 if (is_int($name)) {

--- a/src/Zend/Http/Client/Adapter/Socket.php
+++ b/src/Zend/Http/Client/Adapter/Socket.php
@@ -339,7 +339,6 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
          */
         if ($statusCode == 304 || $statusCode == 204 ||
             $this->method == Zend_Http_Client::HEAD) {
-
             // Close the connection if requested to do so by the server
             if (isset($headers['connection']) && $headers['connection'] == 'close') {
                 $this->close();
@@ -413,9 +412,8 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             if ($this->out_stream) {
                 $response = str_ireplace("Transfer-Encoding: chunked\r\n", '', $response);
             }
-            // Else, if we got the content-length header, read this number of bytes
+        // Else, if we got the content-length header, read this number of bytes
         } elseif (isset($headers['content-length'])) {
-
             // If we got more than one Content-Length header (see ZF-9404) use
             // the last value sent
             if (is_array($headers['content-length'])) {
@@ -428,8 +426,8 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             $chunk       = '';
 
             for ($read_to = $current_pos + $contentLength;
-                 $read_to > $current_pos;
-                 $current_pos = ftell($this->socket)) {
+                $read_to > $current_pos;
+                $current_pos = ftell($this->socket)) {
                 if ($this->out_stream) {
                     if (@stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
                         $this->_checkSocketReadTimeout();
@@ -451,7 +449,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
                 }
             }
 
-            // Fallback: just read the response until EOF
+        // Fallback: just read the response until EOF
         } else {
             do {
                 if ($this->out_stream) {

--- a/src/Zend/Http/Header/SetCookie.php
+++ b/src/Zend/Http/Header/SetCookie.php
@@ -36,7 +36,6 @@
  */
 class Zend_Http_Header_SetCookie
 {
-
     /**
      * Cookie name
      *

--- a/src/Zend/Http/Response.php
+++ b/src/Zend/Http/Response.php
@@ -253,14 +253,13 @@ class Zend_Http_Response
 
         // Decode the body if it was transfer-encoded
         switch (strtolower($this->getHeader('transfer-encoding') ?? '')) {
-
             // Handle chunked body
             case 'chunked':
                 $body = self::decodeChunkedBody($this->body);
                 break;
 
-            // No transfer encoding, or unknown encoding extension:
-            // return body as is
+                // No transfer encoding, or unknown encoding extension:
+                // return body as is
             default:
                 $body = $this->body;
                 break;
@@ -268,13 +267,12 @@ class Zend_Http_Response
 
         // Decode any content-encoding (gzip or deflate) if needed
         switch (strtolower($this->getHeader('content-encoding') ?? '')) {
-
             // Handle gzip encoding
             case 'gzip':
                 $body = self::decodeGzip($body);
                 break;
 
-            // Handle deflate encoding
+                // Handle deflate encoding
             case 'deflate':
                 $body = self::decodeDeflate($body);
                 break;

--- a/src/Zend/Http/UserAgent/Bot.php
+++ b/src/Zend/Http/UserAgent/Bot.php
@@ -31,7 +31,6 @@
 
 class Zend_Http_UserAgent_Bot extends Zend_Http_UserAgent_AbstractDevice
 {
-
     /**
      * User Agent Signatures
      *

--- a/src/Zend/Http/UserAgent/Checker.php
+++ b/src/Zend/Http/UserAgent/Checker.php
@@ -31,7 +31,6 @@
 
 class Zend_Http_UserAgent_Checker extends Zend_Http_UserAgent_Desktop
 {
-
     /**
      * User Agent Signatures
      *

--- a/src/Zend/Http/UserAgent/Desktop.php
+++ b/src/Zend/Http/UserAgent/Desktop.php
@@ -30,7 +30,6 @@
  */
 class Zend_Http_UserAgent_Desktop extends Zend_Http_UserAgent_AbstractDevice
 {
-
     /**
      * Used by default : must be always true
      *

--- a/tests/Zend/Http/Client/ProxyAdapterTest.php
+++ b/tests/Zend/Http/Client/ProxyAdapterTest.php
@@ -203,7 +203,6 @@ class Zend_Http_Client_ProxyAdapterTest extends Zend_Http_Client_SocketTest
  */
 class ZF3189_ProxyAdapter extends Zend_Http_Client_Adapter_Proxy
 {
-
     /**
      * Retrieve the request data from last CONNECT handshake
      * @return string

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -36,7 +36,6 @@
  */
 class Zend_Http_Header_SetCookieTest extends PHPUnit\Framework\TestCase
 {
-
     /**
      * @group ZF2-254
      */


### PR DESCRIPTION
Ran into an issue where ZF1 is preventing headers with underscores from being sent. Technically the HTTP spec allows underscores, they've just been disallowed for legacy reasons (nginx/apache not handling them well for whatever reason, which seems to have been resolved in time).  There's no practical reason that ZF1 should be disallowing the headers from being sent when they contain underscores, so just adding the underscore to allowed character in the preg_match.

Also updating some dependabot versions to clear some PRs that didn't pass.